### PR TITLE
쓸모없는 코드 삭제

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -99,7 +99,6 @@ class User(AbstractBaseUser):
         """
         if self.active_type_id == UserActiveType.TYPES.ACTIVE.value:
             token = RefreshToken.for_user(self)
-            refresh_token_expiration = (datetime.now() + timedelta(days=7)).isoformat()
 
             data = {
                 'access_token': str(token.access_token),


### PR DESCRIPTION
- User 모델의 get_token 메소드 중 refresh_token의 만료일을 가져오는 코드를 변경함에 따라 흔적이 남아있던 이전 방식의 코드를 삭제하였습니다.